### PR TITLE
Add click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mistune==2.0.0a4
 black
 isort
 pyflakes
+click


### PR DESCRIPTION
Fixes missing module:

```
Traceback (most recent call last):
  File "/Users/jamesvaughn/git/sts-kb-articles/tools/markdown2salesforce/md2sf.py", line 6, in <module>
    import click
ModuleNotFoundError: No module named 'click'
```