### PR TITLE
Embed images to html using base64 and converts heading to bolded p

### DIFF
--- a/md2sf.py
+++ b/md2sf.py
@@ -6,12 +6,14 @@ import os
 import click
 import mistune
 from mistune.scanner import escape
-
+import base64
+import magic
 
 class sf_html_render(mistune.HTMLRenderer):
     # This is a custom mistune extension that will override the default
     # behavior of several inline block element handlers to allow them to emit
     # the HTML needed by Saleforce's Knowledge system
+
     def codespan(self, text):
         """override the default `code` block handler"""
         return '<code style="font-size:1em;color:#00f;">' + escape(text) + "</code>"
@@ -19,6 +21,25 @@ class sf_html_render(mistune.HTMLRenderer):
     def paragraph(self, text):
         """override the default paragraph handler"""
         return "<p>" + text + "</p>\n"
+
+    def image(self, url, alt, title=None):
+        """override the default image handler to base64 encode the
+           file content, if the file is available"""
+        
+        if os.path.isfile(url):
+            with open(url, "rb") as image_file:
+                encoded_string = base64.b64encode(image_file.read()).decode('utf-8')
+
+            mimetype = magic.from_file(url, mime=True)
+            url = f'data:{mimetype};base64,{encoded_string}'
+
+        return f'<img alt="{alt}" title="{title}" src="{url}" style="margin-top: 5px; margin-bottom: 5px;" />'
+
+    def heading(self, text, level, **attrs):
+        """Our KB template does not like headers, so converting them just to a bold text
+           First Heading should not have a margin-top"""
+
+        return f"<p style='margin-top: 15px;'><b>{text}</b></p>\n"
 
     def block_code(self, code, info=None):
         """inject the correct `code` block handlers for styling"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ black
 isort
 pyflakes
 click
+python-magic


### PR DESCRIPTION
- Support to embedded base64 images. If the URLs points to a valid file, they are converted to base64 and embedded to the html
- Change HEADING behavior, as we don't use them in our KB template (although I think we should change it) - it converts all HEADING to a bold string with some spacing
- Added python-magic to requirements