### PR TITLE
Convert from python-magic to puremagic

### DIFF
--- a/md2sf.py
+++ b/md2sf.py
@@ -7,7 +7,7 @@ import click
 import mistune
 from mistune.scanner import escape
 import base64
-import magic
+import puremagic as magic
 
 class sf_html_render(mistune.HTMLRenderer):
     # This is a custom mistune extension that will override the default

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ black
 isort
 pyflakes
 click
-python-magic
+puremagic


### PR DESCRIPTION
This change converts the script from python-magic which is dependent upon libmagic to puremagic which has no dependencies.  This is important as many systems will not have libmagic installed by default, including Windows & Alpine among others. 